### PR TITLE
revproxy: add a caching HTTP reverse proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0 h1:ymLjT4f35nQbASLnvxEde4XOBL+Sn7rFuV+FOJqkljg=
 github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0/go.mod h1:6daplAwHHGbUGib4990V3Il26O0OC4aRyvewaaAihaA=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/revproxy/cache.go
+++ b/revproxy/cache.go
@@ -1,0 +1,147 @@
+package revproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/creachadair/atomicfile"
+	"github.com/creachadair/taskgroup"
+)
+
+// cacheLoadLocal reads cached headers and body from the local cache.
+func (s *Server) cacheLoadLocal(hash string) ([]byte, http.Header, error) {
+	data, err := os.ReadFile(s.makePath(hash))
+	if err != nil {
+		return nil, nil, err
+	}
+	return parseCacheObject(data)
+}
+
+// cacheStoreLocal writes the contents of body to the local cache.
+//
+// The file format is a plain-text section at the top recording a subset of the
+// response headers, followed by "\n\n", followed by the response body.
+func (s *Server) cacheStoreLocal(hash string, hdr http.Header, body []byte) error {
+	path := s.makePath(hash)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return atomicfile.Tx(s.makePath(hash), 0600, func(f *atomicfile.File) error {
+		return writeCacheObject(f, hdr, body)
+	})
+}
+
+// cacheLoadS3 reads cached headers and body from the remote S3 cache.
+func (s *Server) cacheLoadS3(ctx context.Context, hash string) ([]byte, http.Header, error) {
+	data, err := s.S3Client.GetData(ctx, s.makeKey(hash))
+	if err != nil {
+		return nil, nil, err
+	}
+	return parseCacheObject(data)
+}
+
+// cacheStoreS3 returns a task that writes the contents of body to the remote
+// S3 cache.
+func (s *Server) cacheStoreS3(hash string, hdr http.Header, body []byte) taskgroup.Task {
+	var buf bytes.Buffer
+	writeCacheObject(&buf, hdr, body)
+	nb := buf.Len()
+	return func() error {
+		sctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		if err := s.S3Client.Put(sctx, s.makeKey(hash), &buf); err != nil {
+			s.logf("[s3] put %q failed: %v", hash, err)
+			s.rspPushError.Add(1)
+		} else {
+			s.rspPush.Add(1)
+			s.rspPushBytes.Add(int64(nb))
+		}
+		return nil
+	}
+}
+
+// cacheLoadMemory reads cached headers and body from the memory cache.
+func (s *Server) cacheLoadMemory(hash string) ([]byte, http.Header, error) {
+	s.mcacheMu.Lock()
+	defer s.mcacheMu.Unlock()
+	v, ok := s.mcache.Get(hash)
+	if !ok {
+		return nil, nil, fs.ErrNotExist
+	}
+	entry := v.(memCacheEntry)
+	if time.Now().After(entry.expires) {
+		s.mcache.Remove(hash)
+		return nil, nil, errors.New("entry expired")
+	}
+	return entry.body, entry.header, nil
+}
+
+// cacheStoreMemory writes the contents of body to the memory cache.
+func (s *Server) cacheStoreMemory(hash string, maxAge time.Duration, hdr http.Header, body []byte) {
+	s.mcacheMu.Lock()
+	defer s.mcacheMu.Unlock()
+	s.mcache.Add(hash, memCacheEntry{
+		header:  hdr,
+		body:    body,
+		expires: time.Now().Add(maxAge),
+	})
+}
+
+// parseCacheDbject parses cached object data to extract the body and headers.
+func parseCacheObject(data []byte) ([]byte, http.Header, error) {
+	hdr, rest, ok := bytes.Cut(data, []byte("\n\n"))
+	if !ok {
+		return nil, nil, errors.New("invalid cache object: missing header")
+	}
+	h := make(http.Header)
+	for _, line := range strings.Split(string(hdr), "\n") {
+		name, value, ok := strings.Cut(line, ": ")
+		if ok {
+			h.Add(name, value)
+		}
+	}
+	return rest, h, nil
+}
+
+// writeCacheObject writes the specified response data into a cache object at w.
+func writeCacheObject(w io.Writer, h http.Header, body []byte) error {
+	hprintf(w, h, "Content-Type", "application/octet-stream")
+	hprintf(w, h, "Date", "")
+	hprintf(w, h, "Etag", "")
+	fmt.Fprint(w, "\n")
+	_, err := w.Write(body)
+	return err
+}
+
+func hprintf(w io.Writer, h http.Header, name, fallback string) {
+	if v := h.Get(name); v != "" {
+		fmt.Fprintf(w, "%s: %s\n", name, v)
+	} else if fallback != "" {
+		fmt.Fprintf(w, "%s: %s\n", name, fallback)
+	}
+}
+
+// setXCacheInfo adds cache-specific headers to h.
+func setXCacheInfo(h http.Header, result, hash string) {
+	h.Set("X-Cache", result)
+	if hash != "" {
+		h.Set("X-Cache-Id", hash[:12])
+	}
+}
+
+// memCacheEntry is the format of entries in the memory cache.
+type memCacheEntry struct {
+	header  http.Header
+	body    []byte
+	expires time.Time
+}

--- a/revproxy/internal_test.go
+++ b/revproxy/internal_test.go
@@ -1,0 +1,30 @@
+package revproxy
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestCheckTarget(t *testing.T) {
+	s := &Server{
+		Targets: []string{"foo.com", "*.bar.com"},
+	}
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"", false},
+		{"nonesuch.org", false},
+		{"foo.com", true},
+		{"other.foo.com", false},
+		{"bar.com", true},
+		{"other.bar.com", true},
+		{"some.other.bar.com", true},
+	}
+	for _, tc := range tests {
+		u := &url.URL{Host: "localhost", Path: tc.input}
+		if got := s.checkTarget(u); got != tc.want {
+			t.Errorf("Check %q: got %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/revproxy/revproxy.go
+++ b/revproxy/revproxy.go
@@ -1,0 +1,364 @@
+// Package revproxy implements a minimal HTTP reverse proxy that caches files
+// locally on disk, backed by objects in an S3 bucket.
+//
+// # Limitations
+//
+// By default, only objects marked "immutable" by the target server are
+// eligible to be cached. Volatile objects that specify a max-age are also
+// cached in-memory, but are not persisted on disk or in S3. If we think it's
+// worthwhile we can spend some time to add more elaborate cache pruning, but
+// for now we're doing the simpler thing.
+package revproxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"expvar"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/creachadair/taskgroup"
+	"github.com/golang/groupcache/lru"
+	"github.com/tailscale/go-cache-plugin/internal/s3util"
+)
+
+// Server is a caching reverse proxy server that caches successful responses to
+// GET requests for certain designated domains.
+//
+// A request URL must have the form:
+//
+//	<base-url>/<host>/<path>[?query][#fragment]
+//
+// If the host matches one of the configured targets, the URL is rewritten as:
+//
+//	https://<host>/<path>[?query][#fragment]
+//
+// and the request is forwarded. Otherwise the request is rejected (HTTP 502).
+// A successful response will be cached if the Cache-Control response from the
+// server does not include "no-store", and does include "immutable".
+//
+// # Cache Format
+//
+// A cached response is a file with a header section and the body, separated by
+// a blank line. Only a subset of response headers are saved.
+//
+// # Cache Responses
+//
+// For requests handled by the proxy, the response includes an "X-Cache" header
+// indicating how the response was obtained:
+//
+//   - "hit, memory": The response was served out of the memory cache.
+//   - "hit, local": The response was served out of the local cache.
+//   - "hit, remote": The response was faulted in from S3.
+//   - "fetch, cached": The response was forwarded to the target and cached.
+//   - "fetch, uncached": The response was forwarded to the target and not cached.
+//
+// For results intersecting with the cache, it also reports a X-Cache-Id giving
+// the storage key of the cache object.
+type Server struct {
+	// Targets is the list of hosts for which the proxy should forward requests.
+	//
+	// Each target is either a hostname ("host.domain.com"), which matches
+	// hostnames exactly, or a pattern of the form "*.domain.com" which matches
+	// hostnames like "domain.com" and "something.domain.com".
+	Targets []string
+
+	// Local is the path of a local cache directory where responses are cached.
+	// It must be non-empty.
+	Local string
+
+	// S3Client is the S3 client used to read and write cache entries to the
+	// backing store. It must be non-nil
+	S3Client *s3util.Client
+
+	// KeyPrefix, if non-empty, is prepended to each key stored into S3, with an
+	// intervening slash.
+	KeyPrefix string
+
+	// Logf, if non-nil, is used to write log messages. If nil, logs are
+	// discarded.
+	Logf func(string, ...any)
+
+	initOnce sync.Once
+	tasks    *taskgroup.Group
+	start    func(taskgroup.Task) *taskgroup.Group
+
+	mcacheMu sync.Mutex // protects mcache
+	mcache   *lru.Cache // short-lived mutable objects
+
+	reqReceived  expvar.Int // total requests received
+	reqMemoryHit expvar.Int // hit in memory cache (volatile)
+	reqLocalHit  expvar.Int // hit in local cache
+	reqLocalMiss expvar.Int // miss in local cache
+	reqFaultHit  expvar.Int // hit in remote (S3) cache
+	reqFaultMiss expvar.Int // miss in remote (S3) cache
+	reqForward   expvar.Int // request forwarded directly to upstream
+	rspSave      expvar.Int // successful response saved in local cache
+	rspSaveError expvar.Int // error saving to local cache
+	rspSaveBytes expvar.Int // bytes written to local cache
+	rspPush      expvar.Int // successful response saved in S3
+	rspPushError expvar.Int // error saving to S3
+	rspPushBytes expvar.Int // bytes written to S3
+}
+
+func (s *Server) init() {
+	s.initOnce.Do(func() {
+		nt := runtime.NumCPU()
+		s.tasks, s.start = taskgroup.New(nil).Limit(nt)
+		s.mcache = lru.New(1 << 16)
+	})
+}
+
+// Metrics returns a map of cache server metrics for s.  The caller is
+// responsible to publish these metrics as desired.
+func (s *Server) Metrics() *expvar.Map {
+	m := new(expvar.Map)
+	m.Set("req_received", &s.reqReceived)
+	m.Set("req_memory_hit", &s.reqMemoryHit)
+	m.Set("req_local_hit", &s.reqLocalHit)
+	m.Set("req_local_miss", &s.reqLocalMiss)
+	m.Set("req_fault_hit", &s.reqFaultHit)
+	m.Set("req_fault_miss", &s.reqFaultMiss)
+	m.Set("req_forward", &s.reqForward)
+	m.Set("rsp_save", &s.rspSave)
+	m.Set("rsp_save_error", &s.rspSaveError)
+	m.Set("rsp_save_bytes", &s.rspSaveBytes)
+	m.Set("rsp_push", &s.rspPush)
+	m.Set("rsp_push_error", &s.rspPushError)
+	m.Set("rsp_push_bytes", &s.rspPushBytes)
+	return m
+}
+
+// ServeHTTP implements the [http.Handler] interface for the proxy.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.init()
+	s.reqReceived.Add(1)
+
+	// Check whether this request is to a target we are permitted to proxy for.
+	if !s.checkTarget(r.URL) {
+		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		return
+	}
+
+	hash := hashRequestURL(r.URL)
+	canCache := s.canCacheRequest(r)
+	if canCache {
+		// Check for a hit on this object in the memory cache.
+		if data, hdr, err := s.cacheLoadMemory(hash); err == nil {
+			s.reqMemoryHit.Add(1)
+			setXCacheInfo(hdr, "hit, memory", hash)
+			writeCachedResponse(w, hdr, data)
+			return
+		}
+
+		// Check for a hit on this object in the local cache.
+		if data, hdr, err := s.cacheLoadLocal(hash); err == nil {
+			s.reqLocalHit.Add(1)
+			setXCacheInfo(hdr, "hit, local", hash)
+			writeCachedResponse(w, hdr, data)
+			return
+		}
+		s.reqLocalMiss.Add(1)
+
+		// Fault in from S3.
+		if data, hdr, err := s.cacheLoadS3(r.Context(), hash); err == nil {
+			s.reqFaultHit.Add(1)
+			if err := s.cacheStoreLocal(hash, hdr, data); err != nil {
+				s.logf("update %q local: %v", hash, err)
+			}
+			setXCacheInfo(hdr, "hit, remote", hash)
+			writeCachedResponse(w, hdr, data)
+			return
+		}
+		s.reqFaultMiss.Add(1)
+	}
+
+	// Reaching here, the object is not already cached locally so we have to
+	// talk to the backend to get it. We need to do this whether or not it is
+	// cacheable. Note we handle each request with its own proxy instance, so
+	// that we can handle each response in context of this request.
+	s.reqForward.Add(1)
+	proxy := &httputil.ReverseProxy{Rewrite: s.rewriteRequest}
+	updateCache := func() {}
+	if canCache {
+		proxy.ModifyResponse = func(rsp *http.Response) error {
+			maxAge, isVolatile := s.canMemoryCache(rsp)
+			if !isVolatile && !s.canCacheResponse(rsp) {
+				// A response we cannot cache at all.
+				setXCacheInfo(rsp.Header, "fetch, uncached", "")
+				return nil
+			}
+
+			// Read out the whole response body so we can update the cache, and
+			// replace the response reader so we can copy it back to the caller.
+			var buf bytes.Buffer
+			rsp.Body = copyReader{
+				Reader: io.TeeReader(rsp.Body, &buf),
+				Closer: rsp.Body,
+			}
+			if isVolatile {
+				setXCacheInfo(rsp.Header, "fetch, cached, volatile", hash)
+				updateCache = func() {
+					body := buf.Bytes()
+					s.cacheStoreMemory(hash, maxAge, rsp.Header, body)
+
+					// N.B. Don't persist on disk or in S3.
+				}
+			} else {
+				setXCacheInfo(rsp.Header, "fetch, cached", hash)
+				updateCache = func() {
+					body := buf.Bytes()
+					if err := s.cacheStoreLocal(hash, rsp.Header, body); err != nil {
+						s.rspSaveError.Add(1)
+						s.logf("save %q to cache: %v", hash, err)
+
+						// N.B.: Don't bother trying to forward to S3 in this case.
+					} else {
+						s.rspSave.Add(1)
+						s.rspSaveBytes.Add(int64(len(body)))
+						s.start(s.cacheStoreS3(hash, rsp.Header, body))
+					}
+				}
+			}
+			return nil
+		}
+	}
+	proxy.ServeHTTP(w, r)
+	updateCache()
+}
+
+// rewriteURL constructs a rewritten request URL based on u, by extracting the
+// target from the path. Precondition: The target is valid (see checkTarget).
+func rewriteURL(u *url.URL) *url.URL {
+	target, rest := parseTarget(u)
+	return &url.URL{
+		Scheme:   "https",
+		Host:     target,
+		Path:     rest,
+		RawQuery: u.RawQuery,
+		Fragment: u.Fragment,
+	}
+}
+
+// rewriteRequest rewrites the inbound request for routing to a target.
+func (s *Server) rewriteRequest(pr *httputil.ProxyRequest) {
+	pr.Out.URL = rewriteURL(pr.In.URL)
+	pr.Out.Host = pr.Out.URL.Host
+}
+
+type copyReader struct {
+	io.Reader
+	io.Closer
+}
+
+// makePath returns the local cache path for the specified request hash.
+func (s *Server) makePath(hash string) string { return filepath.Join(s.Local, hash[:2], hash) }
+
+// makeKey returns the S3 object key for the specified request hash.
+func (s *Server) makeKey(hash string) string { return path.Join(s.KeyPrefix, hash[:2], hash) }
+
+func (s *Server) logf(msg string, args ...any) {
+	if s.Logf != nil {
+		s.Logf(msg, args...)
+	}
+}
+
+// parseTarget splits the first path component from the given URL and returns
+// it and the remainder of the path.
+func parseTarget(u *url.URL) (target, rest string) {
+	target, rest = strings.TrimPrefix(u.Path, "/"), "/"
+	if i := strings.Index(target, "/"); i >= 0 {
+		target, rest = target[:i], target[i:]
+	}
+	return
+}
+
+// checkTarget reports whether the specified request URL matches one of the
+// configured targets for the proxy.
+func (s *Server) checkTarget(u *url.URL) bool {
+	prefix, _ := parseTarget(u)
+	return slices.ContainsFunc(s.Targets, func(s string) bool {
+		if s == prefix {
+			return true
+		} else if tail, ok := strings.CutPrefix(s, "*"); ok {
+			return strings.HasSuffix(prefix, tail) || prefix == strings.TrimPrefix(tail, ".")
+		}
+		return false
+	})
+}
+
+// canCacheRequest reports whether r is a request whose response can be cached.
+func (s *Server) canCacheRequest(r *http.Request) bool {
+	return r.Method == "GET" && !slices.Contains(splitCacheControl(r.Header), "no-cache")
+}
+
+// canCacheResponse reports whether r is a response whose body can be cached.
+func (s *Server) canCacheResponse(rsp *http.Response) bool {
+	if rsp.StatusCode != http.StatusOK {
+		return false
+	}
+	cc := splitCacheControl(rsp.Header)
+	return !slices.Contains(cc, "no-store") && slices.Contains(cc, "immutable")
+}
+
+// canMemoryCache reports whether r is a volatile response whose body can be
+// cached temporarily, and if so returns the maxmimum length of time the cache
+// entry should be valid for.
+func (s *Server) canMemoryCache(rsp *http.Response) (time.Duration, bool) {
+	if rsp.StatusCode != http.StatusOK {
+		return 0, false
+	}
+	var maxAge time.Duration
+	for _, v := range splitCacheControl(rsp.Header) {
+		if v == "no-store" || v == "immutable" {
+			return 0, false // don't cache immutable things in memory
+		}
+		sfx, ok := strings.CutPrefix(v, "max-age=")
+		if !ok {
+			continue
+		}
+		sec, err := strconv.Atoi(sfx)
+		if err == nil {
+			maxAge = time.Duration(min(sec, 3600)) * time.Second
+		}
+	}
+	return maxAge, maxAge > 0
+}
+
+// hashRequest generates the storage digest for the specified request URL.
+func hashRequestURL(u *url.URL) string {
+	ru := rewriteURL(u).String()
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(ru)))
+}
+
+// writeCachedResponse generates an HTTP response for a cached result using the
+// provided headers and body from the cache object.
+func writeCachedResponse(w http.ResponseWriter, hdr http.Header, body []byte) {
+	wh := w.Header()
+	for name, vals := range hdr {
+		for _, val := range vals {
+			wh.Add(name, val)
+		}
+	}
+	w.Write(body)
+}
+
+// splitCacheControl returns the tokens of the cache control header from h.
+func splitCacheControl(h http.Header) []string {
+	fs := strings.Split(h.Get("Cache-Control"), ",")
+	for i, v := range fs {
+		fs[i] = strings.TrimSpace(v)
+	}
+	return fs
+}


### PR DESCRIPTION
Add a new --revproxy flag to the serve command, that exports a minimal HTTP
caching reverse proxy at the specified address. This proxy caches the results
of successful GET requests for a set of hosts matched by --revproxy-targets.
