### PR TITLE
cmd/go-cache-plugin: rearrange how the HTTP services are set up

### DIFF
--- a/cmd/go-cache-plugin/setup.go
+++ b/cmd/go-cache-plugin/setup.go
@@ -1,0 +1,101 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"expvar"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/creachadair/command"
+	"github.com/creachadair/gocache"
+	"github.com/creachadair/gocache/cachedir"
+	"github.com/creachadair/tlsutil"
+	"github.com/tailscale/go-cache-plugin/internal/s3util"
+	"github.com/tailscale/go-cache-plugin/s3cache"
+)
+
+func initCacheServer(env *command.Env) (*gocache.Server, *s3util.Client, error) {
+	switch {
+	case flags.CacheDir == "":
+		return nil, nil, env.Usagef("you must provide a --cache-dir")
+	case flags.S3Bucket == "":
+		return nil, nil, env.Usagef("you must provide an S3 --bucket name")
+	}
+	region, err := getBucketRegion(env.Context(), flags.S3Bucket)
+	if err != nil {
+		return nil, nil, env.Usagef("you must provide an S3 --region name")
+	}
+
+	dir, err := cachedir.New(flags.CacheDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create local cache: %w", err)
+	}
+
+	cfg, err := config.LoadDefaultConfig(env.Context(), config.WithRegion(region))
+	if err != nil {
+		return nil, nil, fmt.Errorf("laod AWS config: %w", err)
+	}
+
+	vprintf("local cache directory: %s", flags.CacheDir)
+	vprintf("S3 cache bucket %q (%s)", flags.S3Bucket, region)
+	client := &s3util.Client{
+		Client: s3.NewFromConfig(cfg),
+		Bucket: flags.S3Bucket,
+	}
+	cache := &s3cache.Cache{
+		Local:             dir,
+		S3Client:          client,
+		KeyPrefix:         flags.KeyPrefix,
+		MinUploadSize:     flags.MinUploadSize,
+		UploadConcurrency: flags.S3Concurrency,
+	}
+	cache.SetMetrics(env.Context(), expvar.NewMap("gocache_host"))
+
+	close := cache.Close
+	if flags.Expiration > 0 {
+		dirClose := dir.Cleanup(flags.Expiration)
+		close = func(ctx context.Context) error {
+			return errors.Join(cache.Close(ctx), dirClose(ctx))
+		}
+	}
+	s := &gocache.Server{
+		Get:         cache.Get,
+		Put:         cache.Put,
+		Close:       close,
+		SetMetrics:  cache.SetMetrics,
+		MaxRequests: flags.Concurrency,
+		Logf:        vprintf,
+		LogRequests: flags.DebugLog,
+	}
+	expvar.Publish("gocache_server", s.Metrics().Get("server"))
+	return s, client, nil
+}
+
+func initServerCert(env *command.Env, hosts []string) (tls.Certificate, error) {
+	ca, err := tlsutil.NewSigningCert(&x509.Certificate{
+		Subject: pkix.Name{Organization: []string{"Tailscale build automation"}},
+	}, 24*time.Hour)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate signing cert: %w", err)
+	}
+	// TODO(creachadair): Install the CA someplace
+
+	sc, err := tlsutil.NewServerCert(&x509.Certificate{
+		Subject:  pkix.Name{Organization: []string{"Go cache plugin reverse proxy"}},
+		DNSNames: hosts,
+	}, 24*time.Hour, ca)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate server cert: %w", err)
+	}
+
+	return sc.TLSCertificate()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tailscale/go-cache-plugin
 
-go 1.22.1
-
-toolchain go1.23.0
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.28
@@ -12,7 +10,9 @@ require (
 	github.com/creachadair/flax v0.0.1
 	github.com/creachadair/gocache v0.0.0-20240828204135-c17fe2fd53a6
 	github.com/creachadair/mds v0.17.1
+	github.com/creachadair/mhttp v0.0.0-20240901170350-fcb7fe4d0ec4
 	github.com/creachadair/taskgroup v0.9.1
+	github.com/creachadair/tlsutil v0.0.0-20240901051800-c769f173a559
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/goproxy/goproxy v0.17.2
 	golang.org/x/sync v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,12 @@ github.com/creachadair/gocache v0.0.0-20240828204135-c17fe2fd53a6 h1:SCF2S1aWvuF
 github.com/creachadair/gocache v0.0.0-20240828204135-c17fe2fd53a6/go.mod h1:iqnJUdWeHbNfn8xWEkLWGQnOo3dqjkZPH9Rk0rjVk0U=
 github.com/creachadair/mds v0.17.1 h1:lXQbTGKmb3nE3aK6OEp29L1gCx6B5ynzlQ6c1KOBurc=
 github.com/creachadair/mds v0.17.1/go.mod h1:4b//mUiL8YldH6TImXjmW45myzTLNS1LLjOmrk888eg=
+github.com/creachadair/mhttp v0.0.0-20240901170350-fcb7fe4d0ec4 h1:K3jpZDY2ny7Yg7hnyisuq8gqMd0vLyTwc50c0RBP81I=
+github.com/creachadair/mhttp v0.0.0-20240901170350-fcb7fe4d0ec4/go.mod h1:gFerCzdOaPgMrgHHm+d65i1ej09AMsMjzWgaOzvaVdQ=
 github.com/creachadair/taskgroup v0.9.1 h1:oam4POtt6PpmUr4us+ycUUfb2mPWc0RmIycte2oWoWw=
 github.com/creachadair/taskgroup v0.9.1/go.mod h1:9oDDPt/5QPS4iylvPMC81GRlj+1je8AFDbjUh4zaQWo=
+github.com/creachadair/tlsutil v0.0.0-20240901051800-c769f173a559 h1:8hlU8ebt2lI//6sFj6ICE6mN6c6Uvj4588XilSqpmu8=
+github.com/creachadair/tlsutil v0.0.0-20240901051800-c769f173a559/go.mod h1:q4s/lgXyN9Cn3nwDvFKbVy65nWNv7mPSYnDM1ShRfjo=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=


### PR DESCRIPTION
The http.ServeMux has some annoying built-in behaviour that is inconvenient for
us here. Specifically, it tries to automatically issue redirects when it cannot
resolve the handler, and that gets in the way of the proxy.

Instead, plumb together a simple direct dispatcher, since we only have a small
number of path options anyway.
