### PR TITLE
cmd/go-cache-plugin: install signing cert when --revproxy is enabled

### DIFF
--- a/cmd/go-cache-plugin/addca_default.go
+++ b/cmd/go-cache-plugin/addca_default.go
@@ -13,5 +13,9 @@ import (
 )
 
 func installSigningCert(env *command.Env, cert tlsutil.Certificate) error {
+	// TODO(creachadair): Maybe crib some other cases from mkcert, if we need
+	// them, for example:
+	// https://github.com/FiloSottile/mkcert/blob/master/truststore_darwin.go
+
 	return errors.New("unable to install a certificate on this system")
 }

--- a/cmd/go-cache-plugin/addca_default.go
+++ b/cmd/go-cache-plugin/addca_default.go
@@ -1,0 +1,17 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !linux
+
+package main
+
+import (
+	"errors"
+
+	"github.com/creachadair/command"
+	"github.com/creachadair/tlsutil"
+)
+
+func installSigningCert(env *command.Env, cert tlsutil.Certificate) error {
+	return errors.New("unable to install a certificate on this system")
+}

--- a/cmd/go-cache-plugin/addca_linux.go
+++ b/cmd/go-cache-plugin/addca_linux.go
@@ -1,0 +1,14 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"github.com/creachadair/command"
+	"github.com/creachadair/tlsutil"
+)
+
+func installSigningCert(env *command.Env, cert tlsutil.Certificate) error {
+	const ubuntuCertFile = "/etc/ssl/certs/ca-certificates.crt"
+	return lockAndAppend(ubuntuCertFile, cert.CertPEM())
+}

--- a/cmd/go-cache-plugin/addca_linux.go
+++ b/cmd/go-cache-plugin/addca_linux.go
@@ -4,11 +4,36 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"os"
+
 	"github.com/creachadair/command"
 	"github.com/creachadair/tlsutil"
+	"golang.org/x/sys/unix"
 )
 
 func installSigningCert(env *command.Env, cert tlsutil.Certificate) error {
 	const ubuntuCertFile = "/etc/ssl/certs/ca-certificates.crt"
 	return lockAndAppend(ubuntuCertFile, cert.CertPEM())
+}
+
+// lockAndAppend acquires an exclusive advisory lock on path, if possible, and
+// appends data to the end of it. It reports an error if path does not exist,
+// or if the lock could not be acquired. The lock is automatically released
+// before returning.
+func lockAndAppend(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND, 0)
+	if err != nil {
+		return err
+	}
+	fd := int(f.Fd())
+	if err := unix.Flock(fd, unix.LOCK_EX); err != nil {
+		f.Close()
+		return fmt.Errorf("lock: %w", err)
+	}
+	defer unix.Flock(fd, unix.LOCK_UN)
+	_, werr := f.Write(data)
+	cerr := f.Close()
+	return errors.Join(werr, cerr)
 }

--- a/cmd/go-cache-plugin/setup.go
+++ b/cmd/go-cache-plugin/setup.go
@@ -204,6 +204,9 @@ func initServerCert(env *command.Env, hosts []string) (tls.Certificate, error) {
 		vprintf("WARNING: %v", err)
 	} else {
 		vprintf("installed signing cert in system store")
+
+		// TODO(creachadair): We should probably clean up old expired certs.
+		// This is OK for ephemeral build/CI workers, though.
 	}
 
 	sc, err := tlsutil.NewServerCert(&x509.Certificate{

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/goproxy/goproxy v0.17.2
 	golang.org/x/sync v0.8.0
+	golang.org/x/sys v0.22.0
 	honnef.co/go/tools v0.5.1
 	tailscale.com v1.72.1
 )
@@ -51,7 +52,6 @@ require (
 	golang.org/x/crypto v0.25.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/mod v0.19.0 // indirect
-	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )


### PR DESCRIPTION
After generating a signing certificate, try to install it in the list of system
trusted certificates. Right now this only works on Ubuntu, and requires that
the program have write access to the cert file. It logs a warning but does not
fail the program if this doesn't succeed.
