### PR TITLE
cmd/go-cache-plugin: custom s3 endpoint url

### DIFF
--- a/cmd/go-cache-plugin/commands.go
+++ b/cmd/go-cache-plugin/commands.go
@@ -26,6 +26,7 @@ var flags struct {
 	CacheDir      string        `flag:"cache-dir,default=$GOCACHE_DIR,Local cache directory (required)"`
 	S3Bucket      string        `flag:"bucket,default=$GOCACHE_S3_BUCKET,S3 bucket name (required)"`
 	S3Region      string        `flag:"region,default=$GOCACHE_S3_REGION,S3 region"`
+	S3Endpoint    string        `flag:"s3-endpoint-url,default=$GOCACHE_S3_ENDPOINT_URL,S3 custom endpoint URL (if unset, use AWS default)"`
 	S3PathStyle   bool          `flag:"s3-path-style,default=$GOCACHE_S3_PATH_STYLE,S3 path-style URLs (optional)"`
 	KeyPrefix     string        `flag:"prefix,default=$GOCACHE_KEY_PREFIX,S3 key prefix (optional)"`
 	MinUploadSize int64         `flag:"min-upload-size,default=$GOCACHE_MIN_SIZE,Minimum object size to upload to S3 (in bytes)"`

--- a/cmd/go-cache-plugin/help.go
+++ b/cmd/go-cache-plugin/help.go
@@ -33,29 +33,30 @@ To make it easier to configure this tool for multiple workflows, most of the
 settings can be set via environment variables as well as flags.
 
    --------------------------------------------------------------------
-   Flag (global)      Variable               Format      Default
+   Flag (global)        Variable                 Format      Default
    --------------------------------------------------------------------
-    --cache-dir       GOCACHE_DIR            path        (required)
-    --bucket          GOCACHE_S3_BUCKET      string      (required)
-    --region          GOCACHE_S3_REGION      string      based on bucket
-    --s3-path-style   GOCACHE_S3_PATH_STYLE  bool        false
-    --prefix          GOCACHE_KEY_PREFIX     string      ""
-    --min-upload-size GOCACHE_MIN_SIZE       int64       0
-    --metrics         GOCACHE_METRICS        bool        false
-    --expiry          GOCACHE_EXPIRY         duration    0
-    -c                GOCACHE_CONCURRENCY    int         runtime.NumCPU
-    -u                GOCACHE_S3_CONCURRENCY duration    runtime.NumCPU
-    -v                GOCACHE_VERBOSE        bool        false
-    --debug           GOCACHE_DEBUG          int         0 (see "help debug")
+    --cache-dir         GOCACHE_DIR              path        (required)
+    --bucket            GOCACHE_S3_BUCKET        string      (required)
+    --region            GOCACHE_S3_REGION        string      based on bucket
+    --s3-path-style     GOCACHE_S3_PATH_STYLE    bool        false
+    --s3-endpoint-url   GOCACHE_S3_ENDPOINT_URL  string      ""
+    --prefix            GOCACHE_KEY_PREFIX       string      ""
+    --min-upload-size   GOCACHE_MIN_SIZE         int64       0
+    --metrics           GOCACHE_METRICS          bool        false
+    --expiry            GOCACHE_EXPIRY           duration    0
+    -c                  GOCACHE_CONCURRENCY      int         runtime.NumCPU
+    -u                  GOCACHE_S3_CONCURRENCY   duration    runtime.NumCPU
+    -v                  GOCACHE_VERBOSE          bool        false
+    --debug             GOCACHE_DEBUG            int         0 (see "help debug")
 
    --------------------------------------------------------------------
-   Flag (serve)       Variable               Format      Default
+   Flag (serve)         Variable                 Format      Default
    --------------------------------------------------------------------
-    --plugin          GOCACHE_PLUGIN         port        (required)
-    --http            GOCACHE_HTTP           [host]:port ""
-    --modproxy        GOCACHE_MODPROXY       bool        false
-    --revproxy        GOCACHE_REVPROXY       host,...    ""
-    --sumdb           GOCACHE_SUMDB          host,...    ""
+    --plugin            GOCACHE_PLUGIN           port        (required)
+    --http              GOCACHE_HTTP             [host]:port ""
+    --modproxy          GOCACHE_MODPROXY         bool        false
+    --revproxy          GOCACHE_REVPROXY         host,...    ""
+    --sumdb             GOCACHE_SUMDB            host,...    ""
 
 See also: "help configure".`,
 	},

--- a/cmd/go-cache-plugin/setup.go
+++ b/cmd/go-cache-plugin/setup.go
@@ -52,10 +52,15 @@ func initCacheServer(env *command.Env) (*gocache.Server, *s3util.Client, error) 
 		return nil, nil, fmt.Errorf("create local cache: %w", err)
 	}
 
-	cfg, err := config.LoadDefaultConfig(env.Context(),
+	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(region),
 		config.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
-	)
+	}
+	if flags.S3Endpoint != "" {
+		vprintf("S3 endpoint URL: %s", flags.S3Endpoint)
+		opts = append(opts, config.WithBaseEndpoint(flags.S3Endpoint))
+	}
+	cfg, err := config.LoadDefaultConfig(env.Context(), opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load AWS config: %w", err)
 	}


### PR DESCRIPTION
Allows to use custom endpoints that implement s3 API.