### PR TITLE
Print metrics in serve mode

### DIFF
--- a/cmd/go-cache-plugin/commands.go
+++ b/cmd/go-cache-plugin/commands.go
@@ -158,6 +158,10 @@ func runServe(env *command.Env) error {
 			log.Printf("server close: %v (ignored)", err)
 		}
 	}
+
+	if flags.Verbose || flags.PrintMetrics {
+		fmt.Fprintln(os.Stderr, s.Metrics())
+	}
 	return nil
 }
 


### PR DESCRIPTION
I noticed that there are no metrics printed when running the plugin in `serve` mode.